### PR TITLE
[FAN-485] set the order of live drops

### DIFF
--- a/src/modules/drops/actions/getDrops.ts
+++ b/src/modules/drops/actions/getDrops.ts
@@ -36,7 +36,7 @@ export const getDrops = createSmartAction<
       accountaddress: params?.address || '',
       limit: params?.limit || 1000,
       offset: params?.offset || 0,
-      ordertype: params?.ordertype || SearchDropsParamOrderType.Positive,
+      ordertype: params?.ordertype || SearchDropsParamOrderType.Inverted,
       state: params?.state || SearchDropsParamState.Live,
     } as ISearchDropsParams,
   },
@@ -58,11 +58,7 @@ export const getDrops = createSmartAction<
         return null;
       }
       return {
-        items: data.data.map(mapSearchDropsItem).sort((a, b) => {
-          return (
-            new Date(a.dropDate).getTime() - new Date(b.dropDate).getTime()
-          );
-        }),
+        items: data.data.map(mapSearchDropsItem),
         total: data.total || 0,
         offset: params?.offset || 0,
       };


### PR DESCRIPTION
Changed the orderType of 'searchdrops' to 'inverted', removed the sorting of returned drops.
- [√] I've performed a code self-review
- [√] I've tested feature or bugfix on my own
- [√] Local build successfully completed
- [√] Branch name and pull request title are according to [the requirements](https://fangible.atlassian.net/wiki/spaces/FAN/pages/62226433/Branches+naming)
